### PR TITLE
Update for TBC 2.5.5 & Fix Deprecated API Usage

### DIFF
--- a/ArenaStats.lua
+++ b/ArenaStats.lua
@@ -1,4 +1,4 @@
-local addonName = "ArenaStats"
+local addonName = "ArenaStatsTBC"
 local addonTitle = select(2, C_AddOns.GetAddOnInfo(addonName))
 local ArenaStats = _G.LibStub("AceAddon-3.0"):NewAddon(addonName,
                                                        "AceConsole-3.0",
@@ -21,155 +21,46 @@ function ArenaStats:OnInitialize()
         profile = {
             minimapButton = {hide = false},
             maxHistory = 0,
-            characterNamesOnHover = {hide = false},
-            showSpec = { hide = false }
+            characterNamesOnHover = {hide = false}
         },
         char = {history = {}}
     })
-
     self:Print("Tracking ready, have a nice session!")
-    self.specSpells = self:GetSpecSpells();
 
     self:RegisterEvent("UPDATE_BATTLEFIELD_STATUS")
     self:RegisterEvent("UPDATE_BATTLEFIELD_SCORE")
     self:RegisterEvent("ZONE_CHANGED_NEW_AREA")
 
-    self:RegisterEvent("ARENA_OPPONENT_UPDATE")
-    self:RegisterEvent("UNIT_AURA")
-    self:RegisterEvent("UNIT_SPELLCAST_START")
-    self:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
-    self:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
-
     self:DrawMinimapIcon()
     self:RegisterOptionsTable()
 
-    self.specTable = {}
     self.arenaEnded = false
-    self.current = { status = "none", stats = {}, units = {} }
+    self.current = {status = "none", stats = {}, units = {}}
     self:Reset()
-end
-
-function ArenaStats:OnSpecDetected(unitName, spec)
-    local existingPlayer = self.specTable[unitName]
-
-    if existingPlayer then
-        return
-    end
-
-    self.specTable[unitName] = spec
-end
-
-function ArenaStats:ScanUnitBuffs(unit)
-    for n = 1, 30 do
-        local auraData = C_UnitAuras.GetAuraDataByIndex(unit, n, "HELPFUL")
-
-        if (not auraData) then
-            break
-        end
-
-        if (not auraData.name) then
-            break
-        end
-
-        local spellID = auraData.spellId
-        local unitCaster = auraData.sourceUnit
-
-        if self.specSpells[spellID] and unitCaster then -- Check for auras that detect a spec
-            local unitPet = string.gsub(unit, "%d$", "pet%1")
-            if UnitIsUnit(unit, unitCaster) or UnitIsUnit(unitPet, unitCaster) then
-                self:OnSpecDetected(GetUnitName(unitCaster, true), self.specSpells[spellID])
-            end
-        end
-    end
-end
-
-function ArenaStats:ARENA_OPPONENT_UPDATE(unit, updateReason)
-    self:ScanUnitBuffs(unit)
-end
-
-function ArenaStats:UNIT_AURA(unit, isFullUpdate, updatedAuras)
-    ArenaStats:ScanUnitBuffs(unit)
-end
-
-function ArenaStats:UNIT_SPELLCAST_START(event, unit, castGUID)
-    local spellName, _, _, _, _, _, _, _, spellID = CastingInfo(event)
-
-    if event then
-        ArenaStats:ScanUnitBuffs(unit)
-    end
-
-    if spellName then
-        if self.specSpells[spellID] and event then
-            local name = GetUnitName(unit, true)
-            self:OnSpecDetected(name, self.specSpells[spellID])
-        end
-    end
-end
-
-function ArenaStats:UNIT_SPELLCAST_CHANNEL_START(event, unit, castGuid, spellId)
-    if unit then 
-        ArenaStats:ScanUnitBuffs(unit)
-    end
-
-    if spellId then
-        if self.specSpells[spellId] and unit then
-            local name = GetUnitName(unit, true)
-            self:OnSpecDetected(name, self.specSpells[spellId])
-        end
-    end
-end
-
-function ArenaStats:UNIT_SPELLCAST_SUCCEEDED(event, unit, castGuid, spellId)
-    if unit then
-        ArenaStats:ScanUnitBuffs(unit)
-    end
-
-    if spellId then
-        if self.specSpells[spellId] and unit then
-            local name = GetUnitName(unit, true)
-            self:OnSpecDetected(name, self.specSpells[spellId])
-        end
-    end
 end
 
 function ArenaStats:ZONE_CHANGED_NEW_AREA()
     local _, instanceType = IsInInstance()
-    if (instanceType == "arena") then
-        self.arenaEnded = false
-        self.specTable = {}
-    end
+    if (instanceType == "arena") then self.arenaEnded = false end
 end
 
 function ArenaStats:UPDATE_BATTLEFIELD_STATUS(_, index)
     local status, mapName, instanceID, levelRangeMin, levelRangeMax, teamSize,
-    isRankedArena, suspendedQueue, bool, queueType =
+          isRankedArena, suspendedQueue, bool, queueType =
         GetBattlefieldStatus(index)
     if (status == "active" and teamSize > 0 and IsActiveBattlefieldArena()) then
         self.current["status"] = status
         self.current["stats"]["teamSize"] = teamSize
         self.current["stats"]["isRanked"] = not IsArenaSkirmish()
         if (self.current["stats"]["startTime"] == nil or
-                self.current["stats"]["startTime"] == '') then
+            self.current["stats"]["startTime"] == '') then
             self.current["stats"]["startTime"] = _G.time()
         end
     end
 end
 
-function ArenaStats:GetSpecOrDefault(unitName)
-    if not unitName then
-        return "Unknown"
-    end
-
-    local detectedSpec = self.specTable[unitName]
-
-    if detectedSpec then
-        return detectedSpec
-    end
-
-    return "Unknown"
-end
-
 function ArenaStats:SetLastArenaRankingData()
+
     local playerTeam = ''
     local greenTeam = {}
     local goldTeam = {}
@@ -177,7 +68,7 @@ function ArenaStats:SetLastArenaRankingData()
     local numScores = GetNumBattlefieldScores()
 
     for i = 1, numScores do
-        local data = { GetBattlefieldScore(i) }
+        local data = {GetBattlefieldScore(i)}
         local teamIndex = data[6]
         if data[1] == myName then
             if teamIndex == 0 then
@@ -201,19 +92,19 @@ function ArenaStats:SetLastArenaRankingData()
             GetBattlefieldTeamInfo(i)
         if teamMMR > 0 then
             if ((i == 0 and playerTeam == 'GREEN') or
-                    (i == 1 and playerTeam == 'GOLD')) then
+                (i == 1 and playerTeam == 'GOLD')) then
                 self.current["stats"]["teamName"] = teamName
                 self.current["stats"]["oldTeamRating"] = oldTeamRating
                 self.current["stats"]["newTeamRating"] = newTeamRating
                 self.current["stats"]["diffRating"] = newTeamRating -
-                    oldTeamRating
+                                                          oldTeamRating
                 self.current["stats"]["mmr"] = teamMMR
             else
                 self.current["stats"]["enemyTeamName"] = teamName
                 self.current["stats"]["enemyOldTeamRating"] = oldTeamRating
                 self.current["stats"]["enemyNewTeamRating"] = newTeamRating
                 self.current["stats"]["enemyDiffRating"] = newTeamRating -
-                    oldTeamRating
+                                                               oldTeamRating
                 self.current["stats"]["enemyMmr"] = teamMMR
             end
         end
@@ -222,12 +113,10 @@ function ArenaStats:SetLastArenaRankingData()
     self.current["stats"]["teamClass"] = {}
     self.current["stats"]["teamCharName"] = {}
     self.current["stats"]["teamRace"] = {}
-    self.current["stats"]["teamSpec"] = {}
 
     self.current["stats"]["enemyClass"] = {}
     self.current["stats"]["enemyName"] = {}
     self.current["stats"]["enemyRace"] = {}
-    self.current["stats"]["enemySpec"] = {}
 
     local playerTeamTable = goldTeam
     local enemyTeamTable = greenTeam
@@ -239,45 +128,19 @@ function ArenaStats:SetLastArenaRankingData()
     -- playerName, killingBlows, honorKills, deaths, honorGained, faction, rank, race, class, classToken, damageDone, healingDone
     for i = 1, #playerTeamTable do
         local row = playerTeamTable[i]
-        local raceUpper
-
-        if not row[8] then
-            raceUpper = ''
-        else
-            local race = LibRaces:GetRaceToken(row[8])
-            if race == nil then
-                raceUpper = ''
-            else
-                raceUpper = race:upper()
-            end
-        end
-
+        local race = LibRaces:GetRaceToken(row[8]):upper()
         self.current["stats"]["teamClass"][i - 1] = row[10]:upper()
         self.current["stats"]["teamCharName"][i - 1] = row[1]
-        self.current["stats"]["teamRace"][i - 1] = raceUpper
-        self.current["stats"]["teamSpec"][i - 1] = self:GetSpecOrDefault(row[1])
+        self.current["stats"]["teamRace"][i - 1] = race
     end
 
     for i = 1, #enemyTeamTable do
         local row = enemyTeamTable[i]
-        local raceUpper
-
-        if not row[8] then
-            raceUpper = ''
-        else
-            local race = LibRaces:GetRaceToken(row[8])
-            if race == nil then
-                raceUpper = ''
-            else
-                raceUpper = race:upper()
-            end
-        end
-
+        local race = LibRaces:GetRaceToken(row[8]):upper()
         self.current["stats"]["enemyClass"][i - 1] = row[10]:upper()
         self.current["stats"]["enemyName"][i - 1] = row[1]
-        self.current["stats"]["enemyRace"][i - 1] = raceUpper
-        self.current["stats"]["enemyFaction"] = self:RaceToFaction(raceUpper)
-        self.current["stats"]["enemySpec"][i - 1] = self:GetSpecOrDefault(row[1])
+        self.current["stats"]["enemyRace"][i - 1] = race
+        self.current["stats"]["enemyFaction"] = self:RaceToFaction(race)
     end
 end
 
@@ -292,11 +155,10 @@ function ArenaStats:RaceToFaction(race)
         return 1
     elseif race == "DWARF" then
         return 1
-    elseif race == "WORGEN" then
-        return 1
     else
         return 0
     end
+
 end
 
 function ArenaStats:UPDATE_BATTLEFIELD_SCORE()
@@ -322,7 +184,6 @@ function ArenaStats:Reset()
 
     self.current["stats"] = {}
     self.current["units"] = {}
-    self.specTable = {}
 end
 
 function ArenaStats:RecordArena()
@@ -342,30 +203,30 @@ end
 
 function ArenaStats:DrawMinimapIcon()
     libDBIcon:Register(addonName,
-        _G.LibStub("LibDataBroker-1.1"):NewDataObject(addonName,
-            {
-                type = "data source",
-                text = addonName,
-                icon = "interface/icons/achievement_arena_2v2_7",
-                OnClick = function(self, button)
-                    if button == "RightButton" then
-                        _G.InterfaceOptionsFrame_OpenToCategory(addonName)
-                        _G.InterfaceOptionsFrame_OpenToCategory(addonName)
-                    else
-                        ArenaStats:Toggle()
-                    end
-                end,
-                OnTooltipShow = function(tooltip)
-                    tooltip:AddLine(string.format("%s |cff777777v%s|r", addonTitle,
-                        "0.2.5"))
-                    tooltip:AddLine(string.format("|cFFCFCFCF%s|r %s", L["Left Click"],
-                        L["to open the main window"]))
-                    tooltip:AddLine(string.format("|cFFCFCFCF%s|r %s", L["Right Click"],
-                        L["to open options"]))
-                    tooltip:AddLine(string.format("|cFFCFCFCF%s|r %s", L["Drag"],
-                        L["to move this button"]))
-                end
-            }), self.db.profile.minimapButton)
+                       _G.LibStub("LibDataBroker-1.1"):NewDataObject(addonName,
+                                                                     {
+        type = "data source",
+        text = addonName,
+        icon = "interface/icons/achievement_arena_2v2_7",
+        OnClick = function(self, button)
+            if button == "RightButton" then
+                _G.InterfaceOptionsFrame_OpenToCategory(addonName)
+                _G.InterfaceOptionsFrame_OpenToCategory(addonName)
+            else
+                ArenaStats:Toggle()
+            end
+        end,
+        OnTooltipShow = function(tooltip)
+            tooltip:AddLine(string.format("%s |cff777777v%s|r", addonTitle,
+                                          "0.1.6"))
+            tooltip:AddLine(string.format("|cFFCFCFCF%s|r %s", L["Left Click"],
+                                          L["to open the main window"]))
+            tooltip:AddLine(string.format("|cFFCFCFCF%s|r %s", L["Right Click"],
+                                          L["to open options"]))
+            tooltip:AddLine(string.format("|cFFCFCFCF%s|r %s", L["Drag"],
+                                          L["to move this button"]))
+        end
+    }), self.db.profile.minimapButton)
 end
 
 function ArenaStats:ToggleMinimapButton()
@@ -437,11 +298,6 @@ function ArenaStats:BuildTable()
             ["teamPlayerRace3"] = row["teamRace"] and row["teamRace"][2] or nil,
             ["teamPlayerRace4"] = row["teamRace"] and row["teamRace"][3] or nil,
             ["teamPlayerRace5"] = row["teamRace"] and row["teamRace"][4] or nil,
-            ["teamPlayerSpec1"] = row["teamSpec"] and row["teamSpec"][0] or nil,
-            ["teamPlayerSpec2"] = row["teamSpec"] and row["teamSpec"][1] or nil,
-            ["teamPlayerSpec3"] = row["teamSpec"] and row["teamSpec"][2] or nil,
-            ["teamPlayerSpec4"] = row["teamSpec"] and row["teamSpec"][3] or nil,
-            ["teamPlayerSpec5"] = row["teamSpec"] and row["teamSpec"][4] or nil,
 
             ["oldTeamRating"] = row["oldTeamRating"],
             ["newTeamRating"] = row["newTeamRating"],
@@ -484,11 +340,6 @@ function ArenaStats:BuildTable()
                 nil,
             ["enemyPlayerRace5"] = row["enemyRace"] and row["enemyRace"][4] or
                 nil,
-            ["enemyPlayerSpec1"] = row["enemySpec"] and row["enemySpec"][0] or nil,
-            ["enemyPlayerSpec2"] = row["enemySpec"] and row["enemySpec"][1] or nil,
-            ["enemyPlayerSpec3"] = row["enemySpec"] and row["enemySpec"][2] or nil,
-            ["enemyPlayerSpec4"] = row["enemySpec"] and row["enemySpec"][3] or nil,
-            ["enemyPlayerSpec5"] = row["enemySpec"] and row["enemySpec"][4] or nil,
             ["enemyFaction"] = row["enemyFaction"],
 
             ["enemyOldTeamRating"] = row["enemyOldTeamRating"],
@@ -519,126 +370,107 @@ function ArenaStats:ResetDatabase()
 end
 
 function ArenaStats:ExportCSV()
+
     local csv =
         "isRanked,startTime,endTime,zoneId,duration,teamName,teamColor,winnerColor," ..
-        "teamPlayerName1,teamPlayerName2,teamPlayerName3,teamPlayerName4,teamPlayerName5," ..
-        "teamPlayerClass1,teamPlayerClass2,teamPlayerClass3,teamPlayerClass4,teamPlayerClass5," ..
-        "teamPlayerRace1,teamPlayerRace2,teamPlayerRace3,teamPlayerRace4,teamPlayerRace5," ..
-        "oldTeamRating,newTeamRating,diffRating,mmr," ..
-        "enemyOldTeamRating,enemyNewTeamRating,enemyDiffRating,enemyMmr,enemyTeamName," ..
-        "enemyPlayerName1,enemyPlayerName2,enemyPlayerName3,enemyPlayerName4,enemyPlayerName5," ..
-        "enemyPlayerClass1,enemyPlayerClass2,enemyPlayerClass3,enemyPlayerClass4,enemyPlayerClass5," ..
-        "enemyPlayerRace1,enemyPlayerRace2,enemyPlayerRace3,enemyPlayerRace4,enemyPlayerRace5,enemyFaction,"..
-        "enemySpec1,enemySpec2,enemySpec3,enemySpec4,enemySpec5," ..
-        "teamSpec1,teamSpec2,teamSpec3,teamSpec4,teamSpec5,"..
-        "\n"
+            "teamPlayerName1,teamPlayerName2,teamPlayerName3,teamPlayerName4,teamPlayerName5," ..
+            "teamPlayerClass1,teamPlayerClass2,teamPlayerClass3,teamPlayerClass4,teamPlayerClass5," ..
+            "teamPlayerRace1,teamPlayerRace2,teamPlayerRace3,teamPlayerRace4,teamPlayerRace5," ..
+            "oldTeamRating,newTeamRating,diffRating,mmr," ..
+            "enemyOldTeamRating,enemyNewTeamRating,enemyDiffRating,enemyMmr,enemyTeamName," ..
+            "enemyPlayerName1,enemyPlayerName2,enemyPlayerName3,enemyPlayerName4,enemyPlayerName5," ..
+            "enemyPlayerClass1,enemyPlayerClass2,enemyPlayerClass3,enemyPlayerClass4,enemyPlayerClass5," ..
+            "enemyPlayerRace1,enemyPlayerRace2,enemyPlayerRace3,enemyPlayerRace4,enemyPlayerRace5,enemyFaction" ..
+            "\n"
 
     for _, row in ipairs(self.db.char.history) do
         csv = csv .. (self:YesOrNo(row["isRanked"])) .. "," ..
-            (row["startTime"] ~= nil and row["startTime"] or "") .. "," ..
-            (row["endTime"] ~= nil and row["endTime"] or "") .. "," ..
-            (row["zoneId"] ~= nil and row["zoneId"] or "") .. "," ..
-            (row["startTime"] ~= nil and row["endTime"] ~= nil and
-                row["endTime"] - row["startTime"] or "") .. "," ..
-            (row["teamName"] ~= nil and row["teamName"] or "") .. "," ..
-            (row["teamColor"] ~= nil and row["teamColor"] or "") .. "," ..
-            (row["winnerColor"] ~= nil and row["winnerColor"] or "") ..
-            "," ..
+                  (row["startTime"] ~= nil and row["startTime"] or "") .. "," ..
+                  (row["endTime"] ~= nil and row["endTime"] or "") .. "," ..
+                  (row["zoneId"] ~= nil and row["zoneId"] or "") .. "," ..
+                  (row["startTime"] ~= nil and row["endTime"] ~= nil and
+                      row["endTime"] - row["startTime"] or "") .. "," ..
 
-            (row["teamCharName"] and row["teamCharName"][0] ~= nil and
-                row["teamCharName"][0] or "") .. "," ..
-            (row["teamCharName"] and row["teamCharName"][1] ~= nil and
-                row["teamCharName"][1] or "") .. "," ..
-            (row["teamCharName"] and row["teamCharName"][2] ~= nil and
-                row["teamCharName"][2] or "") .. "," ..
-            (row["teamCharName"] and row["teamCharName"][3] ~= nil and
-                row["teamCharName"][3] or "") .. "," ..
-            (row["teamCharName"] and row["teamCharName"][4] ~= nil and
-                row["teamCharName"][4] or "") .. "," ..
-            (row["teamClass"] and row["teamClass"][0] ~= nil and
-                row["teamClass"][0] or "") .. "," ..
-            (row["teamClass"] and row["teamClass"][1] ~= nil and
-                row["teamClass"][1] or "") .. "," ..
-            (row["teamClass"] and row["teamClass"][2] ~= nil and
-                row["teamClass"][2] or "") .. "," ..
-            (row["teamClass"] and row["teamClass"][3] ~= nil and
-                row["teamClass"][3] or "") .. "," ..
-            (row["teamClass"] and row["teamClass"][4] ~= nil and
-                row["teamClass"][4] or "") .. "," ..
-            (row["teamRace"] and row["teamRace"][0] ~= nil and
-                row["teamRace"][0] or "") .. "," ..
-            (row["teamRace"] and row["teamRace"][1] ~= nil and
-                row["teamRace"][1] or "") .. "," ..
-            (row["teamRace"] and row["teamRace"][2] ~= nil and
-                row["teamRace"][2] or "") .. "," ..
-            (row["teamRace"] and row["teamRace"][3] ~= nil and
-                row["teamRace"][3] or "") .. "," ..
-            (row["teamRace"] and row["teamRace"][4] ~= nil and
-                row["teamRace"][4] or "") .. "," ..
+                  (row["teamName"] ~= nil and row["teamName"] or "") .. "," ..
+                  (row["teamColor"] ~= nil and row["teamColor"] or "") .. "," ..
+                  (row["winnerColor"] ~= nil and row["winnerColor"] or "") ..
+                  "," ..
 
-            (self:ComputeSafeNumber(row["oldTeamRating"])) .. "," ..
-            (self:ComputeSafeNumber(row["newTeamRating"])) .. "," ..
-            (self:ComputeSafeNumber(row["diffRating"])) .. "," ..
-            (self:ComputeSafeNumber(row["mmr"])) .. "," ..
+                  (row["teamCharName"] and row["teamCharName"][0] ~= nil and
+                      row["teamCharName"][0] or "") .. "," ..
+                  (row["teamCharName"] and row["teamCharName"][1] ~= nil and
+                      row["teamCharName"][1] or "") .. "," ..
+                  (row["teamCharName"] and row["teamCharName"][2] ~= nil and
+                      row["teamCharName"][2] or "") .. "," ..
+                  (row["teamCharName"] and row["teamCharName"][3] ~= nil and
+                      row["teamCharName"][3] or "") .. "," ..
+                  (row["teamCharName"] and row["teamCharName"][4] ~= nil and
+                      row["teamCharName"][4] or "") .. "," ..
+                  (row["teamClass"] and row["teamClass"][0] ~= nil and
+                      row["teamClass"][0] or "") .. "," ..
+                  (row["teamClass"] and row["teamClass"][1] ~= nil and
+                      row["teamClass"][1] or "") .. "," ..
+                  (row["teamClass"] and row["teamClass"][2] ~= nil and
+                      row["teamClass"][2] or "") .. "," ..
+                  (row["teamClass"] and row["teamClass"][3] ~= nil and
+                      row["teamClass"][3] or "") .. "," ..
+                  (row["teamClass"] and row["teamClass"][4] ~= nil and
+                      row["teamClass"][4] or "") .. "," ..
+                  (row["teamRace"] and row["teamRace"][0] ~= nil and
+                      row["teamRace"][0] or "") .. "," ..
+                  (row["teamRace"] and row["teamRace"][1] ~= nil and
+                      row["teamRace"][1] or "") .. "," ..
+                  (row["teamRace"] and row["teamRace"][2] ~= nil and
+                      row["teamRace"][2] or "") .. "," ..
+                  (row["teamRace"] and row["teamRace"][3] ~= nil and
+                      row["teamRace"][3] or "") .. "," ..
+                  (row["teamRace"] and row["teamRace"][4] ~= nil and
+                      row["teamRace"][4] or "") .. "," ..
 
-            (self:ComputeSafeNumber(row["enemyOldTeamRating"])) .. "," ..
-            (self:ComputeSafeNumber(row["enemyNewTeamRating"])) .. "," ..
-            (self:ComputeSafeNumber(row["enemyDiffRating"])) .. "," ..
-            (self:ComputeSafeNumber(row["enemyMmr"])) .. "," ..
-            (row["enemyTeamName"] ~= nil and row["enemyTeamName"] or "") ..
-            "," ..
+                  (self:ComputeSafeNumber(row["oldTeamRating"])) .. "," ..
+                  (self:ComputeSafeNumber(row["newTeamRating"])) .. "," ..
+                  (self:ComputeSafeNumber(row["diffRating"])) .. "," ..
+                  (self:ComputeSafeNumber(row["mmr"])) .. "," ..
 
-            (row["enemyName"] and row["enemyName"][0] ~= nil and
-                row["enemyName"][0] or "") .. "," ..
-            (row["enemyName"] and row["enemyName"][1] ~= nil and
-                row["enemyName"][1] or "") .. "," ..
-            (row["enemyName"] and row["enemyName"][2] ~= nil and
-                row["enemyName"][2] or "") .. "," ..
-            (row["enemyName"] and row["enemyName"][3] ~= nil and
-                row["enemyName"][3] or "") .. "," ..
-            (row["enemyName"] and row["enemyName"][4] ~= nil and
-                row["enemyName"][4] or "") .. "," ..
-            (row["enemyClass"] and row["enemyClass"][0] ~= nil and
-                row["enemyClass"][0] or "") .. "," ..
-            (row["enemyClass"] and row["enemyClass"][1] ~= nil and
-                row["enemyClass"][1] or "") .. "," ..
-            (row["enemyClass"] and row["enemyClass"][2] ~= nil and
-                row["enemyClass"][2] or "") .. "," ..
-            (row["enemyClass"] and row["enemyClass"][3] ~= nil and
-                row["enemyClass"][3] or "") .. "," ..
-            (row["enemyClass"] and row["enemyClass"][4] ~= nil and
-                row["enemyClass"][4] or "") .. "," ..
-            (row["enemyRace"] and row["enemyRace"][0] ~= nil and
-                row["enemyRace"][0] or "") .. "," ..
-            (row["enemyRace"] and row["enemyRace"][1] ~= nil and
-                row["enemyRace"][1] or "") .. "," ..
-            (row["enemyRace"] and row["enemyRace"][2] ~= nil and
-                row["enemyRace"][2] or "") .. "," ..
-            (row["enemyRace"] and row["enemyRace"][3] ~= nil and
-                row["enemyRace"][3] or "") .. "," ..
-            (row["enemyRace"] and row["enemyRace"][4] ~= nil and
-                row["enemyRace"][4] or "") .. "," ..
-            (self:ComputeFaction(row["enemyFaction"])) .. "," ..
-            (row["teamSpec"] and row["teamSpec"][0] ~= nil and
-                row["teamSpec"][0] or "") .. "," ..
-            (row["teamSpec"] and row["teamSpec"][1] ~= nil and
-                row["teamSpec"][1] or "") .. "," ..
-            (row["teamSpec"] and row["teamSpec"][2] ~= nil and
-                row["teamSpec"][2] or "") .. "," ..
-            (row["teamSpec"] and row["teamSpec"][3] ~= nil and
-                row["teamSpec"][3] or "") .. "," ..
-            (row["teamSpec"] and row["teamSpec"][4] ~= nil and
-                row["teamSpec"][4] or "") .. "," ..
-            (row["enemySpec"] and row["enemySpec"][0] ~= nil and
-                row["enemySpec"][0] or "") .. "," ..
-            (row["enemySpec"] and row["enemySpec"][1] ~= nil and
-                row["enemySpec"][1] or "") .. "," ..
-            (row["enemySpec"] and row["enemySpec"][2] ~= nil and
-                row["enemySpec"][2] or "") .. "," ..
-            (row["enemySpec"] and row["enemySpec"][3] ~= nil and
-                row["enemySpec"][3] or "") .. "," ..
-            (row["enemySpec"] and row["enemySpec"][4] ~= nil and
-                row["enemySpec"][4] or "") .. "," .. "\n"
+                  (self:ComputeSafeNumber(row["enemyOldTeamRating"])) .. "," ..
+                  (self:ComputeSafeNumber(row["enemyNewTeamRating"])) .. "," ..
+                  (self:ComputeSafeNumber(row["enemyDiffRating"])) .. "," ..
+                  (self:ComputeSafeNumber(row["enemyMmr"])) .. "," ..
+
+                  (row["enemyTeamName"] ~= nil and row["enemyTeamName"] or "") ..
+                  "," ..
+
+                  (row["enemyName"] and row["enemyName"][0] ~= nil and
+                      row["enemyName"][0] or "") .. "," ..
+                  (row["enemyName"] and row["enemyName"][1] ~= nil and
+                      row["enemyName"][1] or "") .. "," ..
+                  (row["enemyName"] and row["enemyName"][2] ~= nil and
+                      row["enemyName"][2] or "") .. "," ..
+                  (row["enemyName"] and row["enemyName"][3] ~= nil and
+                      row["enemyName"][3] or "") .. "," ..
+                  (row["enemyName"] and row["enemyName"][4] ~= nil and
+                      row["enemyName"][4] or "") .. "," ..
+                  (row["enemyClass"] and row["enemyClass"][0] ~= nil and
+                      row["enemyClass"][0] or "") .. "," ..
+                  (row["enemyClass"] and row["enemyClass"][1] ~= nil and
+                      row["enemyClass"][1] or "") .. "," ..
+                  (row["enemyClass"] and row["enemyClass"][2] ~= nil and
+                      row["enemyClass"][2] or "") .. "," ..
+                  (row["enemyClass"] and row["enemyClass"][3] ~= nil and
+                      row["enemyClass"][3] or "") .. "," ..
+                  (row["enemyClass"] and row["enemyClass"][4] ~= nil and
+                      row["enemyClass"][4] or "") .. "," ..
+                  (row["enemyRace"] and row["enemyRace"][0] ~= nil and
+                      row["enemyRace"][0] or "") .. "," ..
+                  (row["enemyRace"] and row["enemyRace"][1] ~= nil and
+                      row["enemyRace"][1] or "") .. "," ..
+                  (row["enemyRace"] and row["enemyRace"][2] ~= nil and
+                      row["enemyRace"][2] or "") .. "," ..
+                  (row["enemyRace"] and row["enemyRace"][3] ~= nil and
+                      row["enemyRace"][3] or "") .. "," ..
+                  (row["enemyRace"] and row["enemyRace"][4] ~= nil and
+                      row["enemyRace"][4] or "") .. "," ..
+                  (self:ComputeFaction(row["enemyFaction"])) .. "," .. "\n"
     end
     ArenaStats:ExportFrame().eb:SetText(csv)
     ArenaStats:ExportFrame():SetTitle(L["Export"])
@@ -647,7 +479,8 @@ function ArenaStats:ExportCSV()
         "Export String " .. " (" .. string.len(csv) .. ") ")
     ArenaStats:ExportFrame():Show()
     ArenaStats:ExportFrame().eb:SetFocus()
-    ArenaStats:ExportFrame().eb:HighlightText()
+    ArenaStats:ExportFrame().eb:HighlightText(0, ArenaStats:ExportFrame().eb
+                                                  .editBox:GetNumLetters())
 end
 
 function ArenaStats:WebsiteURL()
@@ -655,10 +488,11 @@ function ArenaStats:WebsiteURL()
     ArenaStats:ExportFrame().eb:SetLabel("Tool Website URL")
     ArenaStats:ExportFrame().eb:SetNumLines(1)
     ArenaStats:ExportFrame().eb:SetText(
-        "https://denishamann.github.io/arena-stats-visualizer/")
+        "https://denishamann.github.io/arena-stats-tbc-visualizer/")
     ArenaStats:ExportFrame():Show()
     ArenaStats:ExportFrame().eb:SetFocus()
-    ArenaStats:ExportFrame().eb:HighlightText()
+    ArenaStats:ExportFrame().eb:HighlightText(0, ArenaStats:ExportFrame().eb
+                                                  .editBox:GetNumLetters())
 end
 
 function ArenaStats:ComputeFaction(factionId)

--- a/ArenaStatsTBC.toc
+++ b/ArenaStatsTBC.toc
@@ -1,0 +1,14 @@
+## Interface: 20505
+## Title: ArenaStats - TBC
+## Notes: Arena history and statistics with csv export
+## Author: Kallias-Sulfuron
+## Version: 0.1.6
+## SavedVariables: ArenaStatsTBC
+
+embeds.xml
+locales.xml
+
+ArenaStats.lua
+GUI.lua
+HybridScrollFrame.xml
+options.lua

--- a/GUI.lua
+++ b/GUI.lua
@@ -1,6 +1,6 @@
 local _G = _G
-local addonName = "ArenaStats"
-local addonTitle = select(2, _G.GetAddOnInfo(addonName))
+local addonName = "ArenaStatsTBC"
+local addonTitle = select(2, C_AddOns.GetAddOnInfo(addonName))
 local ArenaStats = _G.LibStub("AceAddon-3.0"):GetAddon(addonName)
 local L = _G.LibStub("AceLocale-3.0"):GetLocale(addonName, true)
 local AceGUI = _G.LibStub("AceGUI-3.0")
@@ -51,9 +51,7 @@ end
 ArenaStats.mapListShortName = {
     [559] = ArenaStats:CreateShortMapName(GetRealZoneText(559)),
     [562] = ArenaStats:CreateShortMapName(GetRealZoneText(562)),
-    [572] = ArenaStats:CreateShortMapName(GetRealZoneText(572)),
-    [617] = ArenaStats:CreateShortMapName(GetRealZoneText(617)),
-    [618] = ArenaStats:CreateShortMapName(GetRealZoneText(618))
+    [572] = ArenaStats:CreateShortMapName(GetRealZoneText(572))
 }
 
 function ArenaStats:CreateGUI()
@@ -64,7 +62,6 @@ function ArenaStats:CreateGUI()
 
     filters.bracket = 0
     filters.arenaType = 0
-    filters.name = ""
 
     asGui.f = AceGUI:Create("Frame")
     asGui.f:Hide()
@@ -116,14 +113,6 @@ function ArenaStats:CreateGUI()
     })
     arenaTypeDropdown:SetValue(filters.arenaType)
     asGui.f:AddChild(arenaTypeDropdown)
-
-    local nameFilter = AceGUI:Create("EditBox")
-    nameFilter:SetLabel(L["Filter By Name"])
-    nameFilter:SetWidth(150)
-    nameFilter:SetCallback("OnEnterPressed", function(widget, event, text)
-        self:OnFilterNameChange(text)
-    end)
-    asGui.f:AddChild(nameFilter)
 
     -- TABLE HEADER
     local tableHeader = AceGUI:Create("SimpleGroup")
@@ -194,12 +183,6 @@ function ArenaStats:OnArenaTypeChange(key)
     self:UpdateTableView()
 end
 
-function ArenaStats:OnFilterNameChange(text)
-    filters.name = text
-    self:SortTable()
-    self:UpdateTableView()
-end
-
 function ArenaStats:CreateScoreButton(tableHeader, width, localeStr)
     local btn = AceGUI:Create("Label")
     btn:SetWidth(width)
@@ -211,30 +194,11 @@ function ArenaStats:CreateScoreButton(tableHeader, width, localeStr)
     tableHeader:AddChild(margin)
 end
 
-function ArenaStats:EnemyNameFilterRow(row)
-    if filters.name == "" then
-        return false
-    end
-    for category, val in pairs(row) do
-        -- find player names within the row
-        if (type(val) == "string" and category:sub(1, #"enemyPlayerName") == "enemyPlayerName") then
-            -- if the filter.name value is anywhere within a substring of the player names
-            if (string.find(val:lower(), filters.name:lower(), 1, true)) then
-                return false
-            end
-        end
-    end
-    return true
-end
-
 function ArenaStats:FilterRow(row)
     if (filters.bracket ~= 0 and row["teamSize"] ~= filters.bracket) then
         return true
     end
     if (filters.arenaType ~= 0 and row["isRanked"] ~= filters.arenaType) then
-        return true
-    end
-    if (self:EnemyNameFilterRow(row)) then
         return true
     end
     return false
@@ -248,34 +212,13 @@ function ArenaStats:SortTable()
     end
 end
 
-
-
-
-function ArenaStats:SortClassSpecTable(a, b)
-    -- Sort nils to the end of the list
-    -- Healer specs pushed to the end (before nils)
-    -- If no spec then sort by class as before
-    if not a or not b then
+function ArenaStats:SortClassTable(a, b)
+    -- regular sort, pushes nils to end
+    if (not a or not b) then
         return not b
+    else
+        return a < b
     end
-    if not a.class or not b.class then
-        return not b.class
-    end
-    if not a.spec or not b.spec then
-        return a.class < b.class
-    end
-    if self:IsHealerSpec(a.spec) and not self:IsHealerSpec(b.spec) then
-        return false
-    end
-    if not self:IsHealerSpec(a.spec) and self:IsHealerSpec(b.spec) then
-        return true
-    end
-    
-    return a.class < b.class
-end
-
-function ArenaStats:IsHealerSpec(spec) 
-    return spec == "Restoration" or spec == "Discipline" or spec == "Holy"
 end
 
 function ArenaStats:RefreshLayout()
@@ -299,23 +242,8 @@ function ArenaStats:RefreshLayout()
                 row["teamPlayerClass3"], row["teamPlayerClass4"],
                 row["teamPlayerClass5"]
             }
-
-            local teamSpecs = {
-                row["teamPlayerSpec1"], row["teamPlayerSpec2"],
-                row["teamPlayerSpec3"], row["teamPlayerSpec4"],
-                row["teamPlayerSpec5"]
-            }
-
-            local teamClassSpec = {
-                { class = teamClasses[1], spec = teamSpecs[1] },
-                { class = teamClasses[2], spec = teamSpecs[2] },
-                { class = teamClasses[3], spec = teamSpecs[3] },
-                { class = teamClasses[4], spec = teamSpecs[4] },
-                { class = teamClasses[5], spec = teamSpecs[5] }
-            }
-
-            table.sort(teamClassSpec, function(a, b)
-                return self:SortClassSpecTable(a, b)
+            table.sort(teamClasses, function(a, b)
+                return ArenaStats:SortClassTable(a, b)
             end)
 
             local teamPlayerNames = {
@@ -335,19 +263,21 @@ function ArenaStats:RefreshLayout()
                 ArenaStats:HideTooltip()
             end)
 
-            button.IconTeamPlayerClass1:SetTexture(self:ClassIconId(teamClassSpec[1]))
-            button.IconTeamPlayerClass2:SetTexture(self:ClassIconId(teamClassSpec[2]))
-            button.IconTeamPlayerClass3:SetTexture(self:ClassIconId(teamClassSpec[3]))
-            button.IconTeamPlayerClass4:SetTexture(self:ClassIconId(teamClassSpec[4]))
-            button.IconTeamPlayerClass5:SetTexture(self:ClassIconId(teamClassSpec[5]))
-
+            button.IconTeamPlayerClass1:SetTexture(self:ClassIconId(
+                                                       teamClasses[1]))
+            button.IconTeamPlayerClass2:SetTexture(self:ClassIconId(
+                                                       teamClasses[2]))
+            button.IconTeamPlayerClass3:SetTexture(self:ClassIconId(
+                                                       teamClasses[3]))
+            button.IconTeamPlayerClass4:SetTexture(self:ClassIconId(
+                                                       teamClasses[4]))
+            button.IconTeamPlayerClass5:SetTexture(self:ClassIconId(
+                                                       teamClasses[5]))
             button.Rating:SetText((row["newTeamRating"] or "-") .. " (" ..
                                       ((row["diffRating"] and row["diffRating"] >
                                           0 and "+" .. row["diffRating"] or
                                           row["diffRating"]) or "0") .. ")")
-
             button.Rating:SetTextColor(self:ColorForRating(row["diffRating"]))
-
             if (row["teamColor"] ~= nil and row["winnerColor"] ~= nil) then
                 if (row["teamColor"] ~= row["winnerColor"]) then
                     button.Rating:SetTextColor(255, 0, 0, 1)
@@ -362,43 +292,16 @@ function ArenaStats:RefreshLayout()
                 row["enemyPlayerClass3"], row["enemyPlayerClass4"],
                 row["enemyPlayerClass5"]
             }
+            table.sort(enemyClasses, function(a, b)
+                return ArenaStats:SortClassTable(a, b)
+            end)
 
-            local enemySpecs = {
-                row["enemyPlayerSpec1"], row["enemyPlayerSpec2"],
-                row["enemyPlayerSpec3"], row["enemyPlayerSpec4"],
-                row["enemyPlayerSpec5"]
-            }
-
-            local enemyClassSpec = {
-                { class = enemyClasses[1], spec = enemySpecs[1] },
-                { class = enemyClasses[2], spec = enemySpecs[2] },
-                { class = enemyClasses[3], spec = enemySpecs[3] },
-                { class = enemyClasses[4], spec = enemySpecs[4] },
-                { class = enemyClasses[5], spec = enemySpecs[5] }
-            }
-
-            -- don't sort if match ends immediately due to no enemies (otherwise gui crashes)
-            local enemiesExist = false
-            for _, v in pairs(enemyClassSpec) do
-                if v.class or v.spec then
-                    enemiesExist = true
-                end
-            end
-
-            if enemiesExist then
-                table.sort(enemyClassSpec, function(a, b)
-                    return self:SortClassSpecTable(a, b)
-                end)
-            end
-
-            button.IconEnemyPlayer1:SetTexture(self:ClassIconId(enemyClassSpec[1]))
-            button.IconEnemyPlayer2:SetTexture(self:ClassIconId(enemyClassSpec[2]))
-            button.IconEnemyPlayer3:SetTexture(self:ClassIconId(enemyClassSpec[3]))
-            button.IconEnemyPlayer4:SetTexture(self:ClassIconId(enemyClassSpec[4]))
-            button.IconEnemyPlayer5:SetTexture(self:ClassIconId(enemyClassSpec[5]))
-
+            button.IconEnemyPlayer1:SetTexture(self:ClassIconId(enemyClasses[1]))
+            button.IconEnemyPlayer2:SetTexture(self:ClassIconId(enemyClasses[2]))
+            button.IconEnemyPlayer3:SetTexture(self:ClassIconId(enemyClasses[3]))
+            button.IconEnemyPlayer4:SetTexture(self:ClassIconId(enemyClasses[4]))
+            button.IconEnemyPlayer5:SetTexture(self:ClassIconId(enemyClasses[5]))
             button.EnemyMMR:SetText(row["enemyMmr"] or "-")
-
             button.EnemyFaction:SetTexture(self:FactionIconId(
                                                row["enemyFaction"]))
 
@@ -446,136 +349,33 @@ function ArenaStats:HumanDuration(seconds)
     return string.format(L["%ih %im"], hours, (minutes - hours * 60))
 end
 
-function ArenaStats:ClassIconId(classSpec)
-    if not classSpec then
-        return 0
-    end
+function ArenaStats:ClassIconId(className)
 
-    local spec = classSpec.spec
-    local className = classSpec.class
-
-    if self.db.profile.showSpec.hide then
-        spec = "" 
-    end
-
-    if not spec then
-        spec = ""
-    end
+    if not className then return 0 end
 
     if className == "MAGE" then
-        if spec == "Frost" then
-            return 135846
-        end
-        if spec == "Fire" then
-            return 135809
-        end
-        if spec == "Arcane" then
-            return 135932
-        end
         return 626001
     elseif className == "PRIEST" then
-        if spec == "Shadow" then
-            return 136207
-        end
-        if spec == "Holy" then
-            return 237542
-        end
-        if spec == "Discipline" then
-            return 135940
-        end
         return 626004
     elseif className == "DRUID" then
-        if spec == "Restoration" then
-            return 136041
-        end
-        if spec == "Feral" then
-            return 136112
-        end
-        if spec == "Balance" then
-            return 136096
-        end
         return 625999
     elseif className == "SHAMAN" then
-        if spec == "Restoration" then
-            return 136052
-        end
-        if spec == "Elemental" then
-            return 136048
-        end
-        if spec == "Enhancement" then
-            return 136051
-        end
         return 626006
     elseif className == "PALADIN" then
-        if spec == "Retribution" then
-            return 135873
-        end
-        if spec == "Holy" then
-            return 135920
-        end
-        if spec == "Protection" then
-            return 236264
-        end
         return 626003
     elseif className == "WARLOCK" then
-        if spec == "Affliction" then
-            return 136145
-        end
-        if spec == "Demonology" then
-            return 136172
-        end
-        if spec == "Destruction" then
-            return 136186
-        end
         return 626007
     elseif className == "WARRIOR" then
-        if spec == "Arms" then
-            return 132355
-        end
-        if spec == "Fury" then
-            return 132347
-        end
-        if spec == "Protection" then
-            return 132341
-        end
         return 626008
     elseif className == "HUNTER" then
-        if spec == "BeastMastery" then
-            return 461112
-        end
-        if spec == "Marksmanship" then
-            return 236179
-        end
-        if spec == "Survival" then
-            return 461113
-        end
         return 626000
     elseif className == "ROGUE" then
-        if spec == "Assassination" then
-            return 132292
-        end
-        if spec == "Combat" then
-            return 132090
-        end
-        if spec == "Subtlety" then
-            return 132320
-        end
         return 626005
-    elseif className == "DEATHKNIGHT" then
-        if spec == "Frost" then
-            return 135773
-        end
-        if spec == "Unholy" then
-            return 135775
-        end
-        if spec == "Blood" then
-            return 135770
-        end
-        return 135771
     end
 end
 
 function ArenaStats:FactionIconId(factionId)
+
     if not factionId then return 0 end
 
     if factionId == 0 then
@@ -586,6 +386,7 @@ function ArenaStats:FactionIconId(factionId)
 end
 
 function ArenaStats:ColorForRating(rating)
+
     if not rating or rating == 0 then return 255, 255, 255, 1 end
 
     if rating < 0 then
@@ -625,5 +426,4 @@ end
 function ArenaStats:HideTooltip() AceGUI.tooltip:Hide() end
 
 function ArenaStats:ExportFrame() return asGui.exportFrame end
-
 function ArenaStats:ExportEditBox() return asGui.exportEditBox end

--- a/options.lua
+++ b/options.lua
@@ -1,5 +1,5 @@
-local addonName = "ArenaStats"
-local _, addonTitle, addonNotes = GetAddOnInfo(addonName)
+local addonName = "ArenaStatsTBC"
+local _, addonTitle, addonNotes = C_AddOns.GetAddOnInfo(addonName)
 local ArenaStats = LibStub("AceAddon-3.0"):GetAddon(addonName)
 local L = LibStub("AceLocale-3.0"):GetLocale(addonName, true)
 local AceConfig = LibStub("AceConfig-3.0")
@@ -25,7 +25,7 @@ function ArenaStats:RegisterOptionsTable()
                 type = "group",
                 name = L["Options"],
                 args = {
-                    intro = { order = 0, type = "description", name = addonNotes },
+                    intro = {order = 0, type = "description", name = addonNotes},
                     group1 = {
                         order = 10,
                         type = "group",
@@ -89,32 +89,12 @@ function ArenaStats:RegisterOptionsTable()
                                 name = L["Show character names on hover"],
                                 get = function()
                                     return not self.db.profile
-                                        .characterNamesOnHover.hide
+                                               .characterNamesOnHover.hide
                                 end,
                                 set = function()
                                     self.db.profile.characterNamesOnHover.hide =
                                         not self.db.profile
-                                        .characterNamesOnHover.hide
-                                end
-                            }
-                        }
-                    },
-                    group4 = {
-                        order = 40,
-                        type = "group",
-                        name = L["Spec Detection"],
-                        inline = true,
-                        args = {
-                            showSpec = {
-                                order = 41,
-                                type = "toggle",
-                                name = L["Show specialization"],
-                                get = function()
-                                    return not self.db.profile.showSpec.hide
-                                end,
-                                set = function()
-                                    self.db.profile.showSpec.hide =
-                                        not self.db.profile.showSpec.hide
+                                            .characterNamesOnHover.hide
                                 end
                             }
                         }
@@ -123,9 +103,9 @@ function ArenaStats:RegisterOptionsTable()
             },
             Profiles = AceDBOptions:GetOptionsTable(ArenaStats.db)
         }
-    }, { "arenastats", "as" })
+    }, {"arenastats", "as"})
     AceConfigDialog:AddToBlizOptions(addonName, nil, nil, "General")
 
     AceConfigDialog:AddToBlizOptions(addonName, "Profiles", addonName,
-        "Profiles")
+                                     "Profiles")
 end


### PR DESCRIPTION
Update the addon to be fully compatible with TBC Classic version 2.5.5 and resolves Lua errors caused by deprecated API calls.

- TOC Update: Updated Interface to 20505 and bumped version to 0.1.6.
- API Fixes: Replaced all instances of the deprecated global `GetAddOnInfo` with `C_AddOns.GetAddOnInfo` in `ArenaStats.lua`, `GUI.lua` and `options.lua`. This fixes the "attempt to call nil value" errors on startup.
- Tooltip: Updated the version number displayed in the minimap button tooltip to match the new version.